### PR TITLE
fix: prevent stale .git/index.lock from blocking git commands

### DIFF
--- a/.claude/hooks/clean-git-lock.sh
+++ b/.claude/hooks/clean-git-lock.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# PreToolUse hook: remove stale .git/index.lock before git commands
+# Reads JSON from stdin: {"tool_name": "Bash", "tool_input": {"command": "..."}, "cwd": "..."}
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
+
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+echo "$COMMAND" | grep -qE "(^|\s)git(\s|$)" || exit 0
+
+# Find the git repo root from cwd
+CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
+[ -z "$CWD" ] && exit 0
+
+GIT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null)
+[ -z "$GIT_ROOT" ] && exit 0
+
+LOCK_FILE="$GIT_ROOT/.git/index.lock"
+[ -f "$LOCK_FILE" ] || exit 0
+
+# Check if any process actually holds the lock
+LOCK_HELD=false
+if command -v lsof >/dev/null 2>&1; then
+  lsof "$LOCK_FILE" >/dev/null 2>&1 && LOCK_HELD=true
+elif command -v fuser >/dev/null 2>&1; then
+  fuser "$LOCK_FILE" >/dev/null 2>&1 && LOCK_HELD=true
+else
+  # Fallback: treat lock older than 60s as stale
+  LOCK_AGE=$(( $(date +%s) - $(stat -f %m "$LOCK_FILE" 2>/dev/null || stat -c %Y "$LOCK_FILE" 2>/dev/null || echo 0) ))
+  [ "$LOCK_AGE" -le 60 ] && LOCK_HELD=true
+fi
+
+if [ "$LOCK_HELD" = "false" ]; then
+  rm -f "$LOCK_FILE"
+  echo "[clean-git-lock] Removed stale $LOCK_FILE" >&2
+fi
+
+exit 0

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -5,8 +5,8 @@
 
 input=$(cat)
 
-# workarround .git/index.lock issue
-GIT_OPTIONAL_LOCKS=0
+# Prevent opportunistic locking by background git operations (avoids stale .git/index.lock)
+export GIT_OPTIONAL_LOCKS=0
 
 # Extract values using jq
 MODEL=$(echo "$input" | jq -r '.model.display_name // "Claude"')

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,8 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0",
-    "CLAUDE_CODE_NO_FLICKER": "1"
+    "CLAUDE_CODE_NO_FLICKER": "1",
+    "GIT_OPTIONAL_LOCKS": "0"
   },
   "permissions": {
     "allow": [
@@ -85,6 +86,15 @@
   },
   "hooks": {
     "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/clean-git-lock.sh"
+          }
+        ]
+      },
       {
         "matcher": "Bash",
         "hooks": [


### PR DESCRIPTION
## Why

- Claude Code background git operations (e.g. status checks for context) acquire optional locks and leave stale `.git/index.lock` files when interrupted, blocking subsequent user git commands
- Related upstream issues: [#11005](https://github.com/anthropics/claude-code/issues/11005), [#28546](https://github.com/anthropics/claude-code/issues/28546)
- The existing `GIT_OPTIONAL_LOCKS=0` in `statusline.sh` was set without `export`, so git subprocesses never inherited it

## What

- Add `GIT_OPTIONAL_LOCKS=0` to `settings.json` `env` block — applies to all git operations run by Claude Code (root fix)
- Fix `statusline.sh`: `GIT_OPTIONAL_LOCKS=0` → `export GIT_OPTIONAL_LOCKS=0` so child git processes inherit the variable
- Add `clean-git-lock.sh` PreToolUse hook: before any `git` Bash command, checks for `.git/index.lock` and removes it if no process holds it (`lsof` → `fuser` → 60s age fallback)

## Reference

- https://github.com/anthropics/claude-code/issues/11005
- https://git-scm.com/docs/git (--no-optional-locks / GIT_OPTIONAL_LOCKS)
- https://github.com/henrikruscon/hyper-statusline/pull/94