### PR TITLE
feat: add sound to task completion notification

### DIFF
--- a/.claude/hooks/notify-done.sh
+++ b/.claude/hooks/notify-done.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Stop hook: macOS desktop notification when Claude finishes a task
+# Stop hook: macOS desktop notification with sound when Claude finishes a task
 # Reads JSON from stdin: {"stop_reason": "...", "is_error": false, ...}
 INPUT=$(cat)
 IS_ERROR=$(echo "$INPUT" | jq -r '.is_error // false')
@@ -7,14 +7,16 @@ IS_ERROR=$(echo "$INPUT" | jq -r '.is_error // false')
 if [ "$IS_ERROR" = "true" ]; then
   TITLE="Claude Code - エラー"
   MSG="タスクがエラーで終了しました"
+  SOUND="Basso"
 else
   TITLE="Claude Code - 完了"
   MSG="タスクが完了しました"
+  SOUND="Glass"
 fi
 
-# macOS notification
+# macOS notification with sound (sound name plays via Notification Center)
 if command -v osascript >/dev/null 2>&1; then
-  osascript -e "display notification \"$MSG\" with title \"$TITLE\"" 2>/dev/null || true
+  osascript -e "display notification \"$MSG\" with title \"$TITLE\" sound name \"$SOUND\"" 2>/dev/null || true
 fi
 
 exit 0


### PR DESCRIPTION
## Why

- タスク完了時の通知に音がなく、画面を見ていないと気づきにくかった

## What

- 完了時: `Glass` サウンド（クリアな音）
- エラー時: `Basso` サウンド（低く注意を促す音）
- `osascript` の `sound name` パラメータを使い、通知と音を同時に発火

## Reference

- N/A