### PR TITLE
feat: add custom subagents and multi-agent dispatch rules

### DIFF
--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,0 +1,43 @@
+---
+name: researcher
+description: |
+  MUST BE USED for any investigation, research, or exploration task that does NOT require
+  file modification. Automatically delegate to this agent when the work involves:
+  - Web search or fetching external documentation
+  - Reading and summarizing existing code/configs without changing them
+  - Answering "how does X work", "what is the best practice for Y" questions
+  - Exploring an unfamiliar codebase area before planning changes
+  - Running shell commands that only read state (git log, ls, cat, grep, etc.)
+  This agent CANNOT write or edit files. It reports findings back to the orchestrator.
+model: claude-haiku-4-5-20251001
+tools:
+  - Read
+  - Glob
+  - Grep
+  - WebSearch
+  - WebFetch
+  - Bash
+---
+
+You are a research and exploration agent. Your role is to investigate, gather information,
+and summarize findings — you do NOT modify files.
+
+## Your responsibilities
+
+- Search the web for documentation, best practices, and solutions
+- Read and analyze existing files to understand the current state
+- Run read-only shell commands (git log, ls, grep, etc.) to inspect the environment
+- Summarize what you find clearly so the orchestrator can act on it
+
+## Output format
+
+Always return:
+1. **Summary** — one-paragraph answer to the research question
+2. **Key findings** — bullet list of important facts discovered
+3. **Recommendations** — specific actionable suggestions for the orchestrator
+
+## Constraints
+
+- NEVER use Write, Edit, or any file-modifying tools
+- Keep responses concise — the orchestrator needs facts, not essays
+- If web search returns irrelevant results, say so explicitly rather than guessing

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,0 +1,61 @@
+---
+name: security-auditor
+description: |
+  MUST BE USED for any security-focused review of configs, scripts, or hook definitions.
+  Automatically delegate to this agent when:
+  - New hooks or permission rules are added to .claude/settings.json
+  - A commit is about to be made and secrets/credential review is needed
+  - User asks to "audit", "security review", or "check for leaks" in any file
+  - setup.sh or symlink scripts are modified (verify no sensitive paths exposed)
+  Reports findings only; does NOT modify files.
+model: claude-haiku-4-5-20251001
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+You are a security auditor for dotfiles and Claude Code harness configurations.
+Your role is to identify security risks without modifying any files.
+
+## Audit areas
+
+**Secrets & credentials**
+- Hardcoded API keys, tokens, passwords in any file
+- Files that should be in .gitignore but aren't
+- Environment variables that expose sensitive values
+
+**Claude Code hooks**
+- Hooks that can be bypassed (exit 0 without proper checks)
+- Overly permissive `allow` rules in settings.json
+- Missing deny rules for sensitive paths
+- Hook scripts that read from unreliable env vars instead of stdin
+
+**Symlinks (setup.sh)**
+- Symlinks that expose `~/.ssh`, `~/.aws`, or similar to the repo
+- World-readable permissions on sensitive directories
+
+**Permissions**
+- Files with 777 or overly permissive chmod
+- Scripts runnable by others that contain sensitive logic
+
+## Output format
+
+```
+## Security Audit Report
+
+### Critical (fix immediately)
+- <issue + file:line>
+
+### High (fix before commit)
+- <issue + file:line>
+
+### Medium (fix soon)
+- <issue + file:line>
+
+### Low / Informational
+- <note>
+
+### Verdict: CLEAN | ISSUES FOUND
+```

--- a/.claude/agents/shell-reviewer.md
+++ b/.claude/agents/shell-reviewer.md
@@ -1,0 +1,67 @@
+---
+name: shell-reviewer
+description: |
+  MUST BE USED when reviewing, auditing, or linting shell scripts (.sh, .bash, setup scripts).
+  Automatically delegate to this agent when:
+  - A shell script was just written or modified and needs quality review
+  - User asks to "review", "check", "audit", or "lint" a shell script
+  - A Bash hook script needs validation before deployment
+  - setup.sh or any installer script is modified
+  Returns a structured review report; the orchestrator decides whether to apply fixes.
+model: claude-haiku-4-5-20251001
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+You are a shell script review specialist. Your role is to audit shell scripts for
+correctness, portability, and security issues.
+
+## Review checklist
+
+For every script, check:
+
+**Correctness**
+- Shebang is correct (`#!/usr/bin/env bash` or `#!/bin/bash`)
+- `set -euo pipefail` present for scripts that should fail-fast
+- Variables are quoted (`"$var"` not `$var`)
+- Exit codes are handled correctly
+
+**Portability**
+- No zsh/fish-specific syntax in `.sh` files
+- POSIX-compliant where possible
+- No bashisms when `#!/bin/sh` is declared
+
+**Security**
+- No hardcoded credentials or secrets
+- No `eval` with untrusted input
+- No `curl | bash` patterns
+- Sensitive paths not leaked to stdout
+
+**Hook scripts (`.claude/hooks/*.sh`)**
+- Reads JSON from stdin via `INPUT=$(cat)`
+- Parses fields with `jq`
+- Exits with code 2 to block, 0 to allow
+- Writes block messages to stderr
+
+## Output format
+
+Return a structured report:
+```
+## Shell Review: <filename>
+
+### Issues (must fix)
+- <issue>
+
+### Warnings (should fix)
+- <warning>
+
+### Suggestions (optional)
+- <suggestion>
+
+### Verdict: PASS | FAIL | PASS WITH WARNINGS
+```
+
+If `shellcheck` is available, run it and include its output.

--- a/.config/opencode/package-lock.json
+++ b/.config/opencode/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "opencode",
-  "version": "file:../../dotfiles/.config/opencode",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9,7 +8,7 @@
         "@opencode-ai/plugin": "1.4.10"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
       "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
@@ -22,7 +21,7 @@
         "darwin"
       ]
     },
-    "../../dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
       "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
@@ -35,7 +34,7 @@
         "darwin"
       ]
     },
-    "../../dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
       "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
@@ -48,7 +47,7 @@
         "linux"
       ]
     },
-    "../../dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
       "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
@@ -61,7 +60,7 @@
         "linux"
       ]
     },
-    "../../dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
       "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
@@ -74,7 +73,7 @@
         "linux"
       ]
     },
-    "../../dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
       "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
@@ -87,7 +86,7 @@
         "win32"
       ]
     },
-    "../../dotfiles/.config/opencode/node_modules/@opencode-ai/plugin": {
+    "node_modules/@opencode-ai/plugin": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.10.tgz",
       "integrity": "sha512-35Za2LT2oNWnBoonmPjN1Z9PB4+ir2a6GbZ3nIZQQL/96mqzTRkT1FqUkQc3bdMmfT1R1rqOd5aMzkIXMqC7dA==",
@@ -110,7 +109,7 @@
         }
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/@opencode-ai/sdk": {
+    "node_modules/@opencode-ai/sdk": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.10.tgz",
       "integrity": "sha512-Yaddcs/COp0hwiCxgobSZyDUN0nHgkEFL4bG0BQxwd52SGAysOr6A6L0ihfkuhVx0kbi9eXWgZk4ydNOrnur5w==",
@@ -119,13 +118,13 @@
         "cross-spawn": "7.0.6"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/@standard-schema/spec": {
+    "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
-    "../../dotfiles/.config/opencode/node_modules/cross-spawn": {
+    "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
@@ -139,7 +138,7 @@
         "node": ">= 8"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/detect-libc": {
+    "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
@@ -149,7 +148,7 @@
         "node": ">=8"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/effect": {
+    "node_modules/effect": {
       "version": "4.0.0-beta.48",
       "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
       "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
@@ -167,7 +166,7 @@
         "yaml": "^2.8.3"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/fast-check": {
+    "node_modules/fast-check": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
       "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
@@ -189,13 +188,13 @@
         "node": ">=12.17.0"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/find-my-way-ts": {
+    "node_modules/find-my-way-ts": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
       "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
       "license": "MIT"
     },
-    "../../dotfiles/.config/opencode/node_modules/ini": {
+    "node_modules/ini": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
       "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
@@ -204,19 +203,19 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/isexe": {
+    "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "../../dotfiles/.config/opencode/node_modules/kubernetes-types": {
+    "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
       "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
       "license": "Apache-2.0"
     },
-    "../../dotfiles/.config/opencode/node_modules/msgpackr": {
+    "node_modules/msgpackr": {
       "version": "1.11.10",
       "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
       "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
@@ -225,7 +224,7 @@
         "msgpackr-extract": "^3.0.2"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/msgpackr-extract": {
+    "node_modules/msgpackr-extract": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
       "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
@@ -247,13 +246,13 @@
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/multipasta": {
+    "node_modules/multipasta": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
       "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "license": "MIT"
     },
-    "../../dotfiles/.config/opencode/node_modules/node-gyp-build-optional-packages": {
+    "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
       "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
@@ -268,7 +267,7 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/path-key": {
+    "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
@@ -277,7 +276,7 @@
         "node": ">=8"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/pure-rand": {
+    "node_modules/pure-rand": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
       "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
@@ -293,7 +292,7 @@
       ],
       "license": "MIT"
     },
-    "../../dotfiles/.config/opencode/node_modules/shebang-command": {
+    "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
@@ -305,7 +304,7 @@
         "node": ">=8"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/shebang-regex": {
+    "node_modules/shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
@@ -314,7 +313,7 @@
         "node": ">=8"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/toml": {
+    "node_modules/toml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
       "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
@@ -323,7 +322,7 @@
         "node": ">=20"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/uuid": {
+    "node_modules/uuid": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
       "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
@@ -336,7 +335,7 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/which": {
+    "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
@@ -351,7 +350,7 @@
         "node": ">= 8"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/yaml": {
+    "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
@@ -366,898 +365,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "../../dotfiles/.config/opencode/node_modules/zod": {
+    "node_modules/zod": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
       "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ]
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ]
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
-      "cpu": [
-        "arm"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ]
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ]
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ]
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ]
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@opencode-ai/plugin": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.10.tgz",
-      "integrity": "sha512-35Za2LT2oNWnBoonmPjN1Z9PB4+ir2a6GbZ3nIZQQL/96mqzTRkT1FqUkQc3bdMmfT1R1rqOd5aMzkIXMqC7dA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@opencode-ai/sdk": "1.4.10",
-        "effect": "4.0.0-beta.48",
-        "zod": "4.1.8"
-      },
-      "peerDependencies": {
-        "@opentui/core": ">=0.1.100",
-        "@opentui/solid": ">=0.1.100"
-      },
-      "peerDependenciesMeta": {
-        "@opentui/core": {
-          "optional": true
-        },
-        "@opentui/solid": {
-          "optional": true
-        }
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@opencode-ai/sdk": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.10.tgz",
-      "integrity": "sha512-Yaddcs/COp0hwiCxgobSZyDUN0nHgkEFL4bG0BQxwd52SGAysOr6A6L0ihfkuhVx0kbi9eXWgZk4ydNOrnur5w==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "7.0.6"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/effect": {
-      "version": "4.0.0-beta.48",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
-      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
-        "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
-        "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
-        "multipasta": "^0.2.7",
-        "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/fast-check": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
-      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=12.17.0"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/find-my-way-ts": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
-      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "extraneous": true,
-      "license": "ISC"
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/kubernetes-types": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
-      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
-      "extraneous": true,
-      "license": "Apache-2.0"
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/msgpackr": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
-      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
-      "extraneous": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build-optional-packages": "5.2.2"
-      },
-      "bin": {
-        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
-      },
-      "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/multipasta": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
-      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/node-gyp-build-optional-packages": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
-      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.1"
-      },
-      "bin": {
-        "node-gyp-build-optional-packages": "bin.js",
-        "node-gyp-build-optional-packages-optional": "optional.js",
-        "node-gyp-build-optional-packages-test": "build-test.js"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "extraneous": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "../../dotfiles/dotfiles/.config/opencode/node_modules/zod": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
-      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ]
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ]
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
-      "cpu": [
-        "arm"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ]
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ]
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ]
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ]
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@opencode-ai/plugin": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.10.tgz",
-      "integrity": "sha512-35Za2LT2oNWnBoonmPjN1Z9PB4+ir2a6GbZ3nIZQQL/96mqzTRkT1FqUkQc3bdMmfT1R1rqOd5aMzkIXMqC7dA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@opencode-ai/sdk": "1.4.10",
-        "effect": "4.0.0-beta.48",
-        "zod": "4.1.8"
-      },
-      "peerDependencies": {
-        "@opentui/core": ">=0.1.100",
-        "@opentui/solid": ">=0.1.100"
-      },
-      "peerDependenciesMeta": {
-        "@opentui/core": {
-          "optional": true
-        },
-        "@opentui/solid": {
-          "optional": true
-        }
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@opencode-ai/sdk": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.10.tgz",
-      "integrity": "sha512-Yaddcs/COp0hwiCxgobSZyDUN0nHgkEFL4bG0BQxwd52SGAysOr6A6L0ihfkuhVx0kbi9eXWgZk4ydNOrnur5w==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "7.0.6"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/effect": {
-      "version": "4.0.0-beta.48",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
-      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
-        "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
-        "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
-        "multipasta": "^0.2.7",
-        "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/fast-check": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
-      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=12.17.0"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/find-my-way-ts": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
-      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "extraneous": true,
-      "license": "ISC"
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/kubernetes-types": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
-      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
-      "extraneous": true,
-      "license": "Apache-2.0"
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/msgpackr": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
-      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
-      "extraneous": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build-optional-packages": "5.2.2"
-      },
-      "bin": {
-        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
-      },
-      "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/multipasta": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
-      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/node-gyp-build-optional-packages": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
-      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.1"
-      },
-      "bin": {
-        "node-gyp-build-optional-packages": "bin.js",
-        "node-gyp-build-optional-packages-optional": "optional.js",
-        "node-gyp-build-optional-packages-test": "build-test.js"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "extraneous": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/zod": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
-      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@opencode-ai/plugin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.0.tgz",
-      "integrity": "sha512-VFIff6LHp/RVaJdrK3EQ1ijx0K1tV5i1DY5YJ+pRqwC6trunPHbvqSN0GHSTZX39RdnSc+XuzCTZQCy1W2qNOg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@opencode-ai/sdk": "1.4.0",
-        "zod": "4.1.8"
-      },
-      "peerDependencies": {
-        "@opentui/core": ">=0.1.97",
-        "@opentui/solid": ">=0.1.97"
-      },
-      "peerDependenciesMeta": {
-        "@opentui/core": {
-          "optional": true
-        },
-        "@opentui/solid": {
-          "optional": true
-        }
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/@opencode-ai/sdk": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.0.tgz",
-      "integrity": "sha512-mfa3MzhqNM+Az4bgPDDXL3NdG+aYOHClXmT6/4qLxf2ulyfPpMNHqb9Dfmo4D8UfmrDsPuJHmbune73/nUQnuw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "7.0.6"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "extraneous": true,
-      "license": "ISC"
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "../../dotfiles/dotfiles/dotfiles/dotfiles/.config/opencode/node_modules/zod": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
-      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
-      "extraneous": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,41 @@ Always verify symlink targets exist before creating new ones.
 
 **Destructive ops**: `git reset --hard`, `rm -rf`, force push are blocked by hooks/deny rules. Do not attempt to bypass.
 
+## Multi-Agent Dispatch Rules
+
+Agent Teams is enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`).
+Custom subagents live in `.claude/agents/`. **Use them proactively.**
+
+### Auto-dispatch to subagents
+
+| Condition | Action |
+|---|---|
+| Task has 3+ independent parts with no shared state | Spawn parallel subagents |
+| Research needed before implementation | Delegate to `researcher` first, then implement |
+| Shell script written or modified | Delegate review to `shell-reviewer` |
+| New hook or permission rule added | Delegate audit to `security-auditor` |
+| Single small change (<2 min) | No dispatch — do it directly |
+
+### Parallel dispatch (spawn simultaneously when tasks are independent)
+
+```
+investigate X  +  implement Y  +  review Z
+     ↓                ↓               ↓
+ researcher      main thread     shell-reviewer
+```
+
+### Sequential dispatch (when output of A feeds B)
+
+```
+researcher → findings → implement → shell-reviewer → verdict → commit
+```
+
+### Do NOT dispatch when
+
+- Single-file change with no research needed
+- Task needs mid-execution user confirmation
+- Task takes under 30 seconds
+
 ## Available Skills
 - `/codex-review` — Codex CLI code review
 - `/zellij-swarm` — Parallel agent orchestration

--- a/setup.sh
+++ b/setup.sh
@@ -101,7 +101,9 @@ link .claude/settings.json "$HOME/.claude/settings.json"
 link .claude/scripts "$HOME/.claude/scripts"
 link .claude/skills "$HOME/.claude/skills"
 link .claude/rules "$HOME/.claude/rules"
+link .claude/agents "$HOME/.claude/agents"
 link .claude/keybindings.json "$HOME/.claude/keybindings.json"
+link .claude/hooks "$HOME/.claude/hooks"
 
 # Other application links
 link .hammerspoon "$HOME/.hammerspoon"


### PR DESCRIPTION
## Why

- Currently sub-agents require explicit `@mention` for each invocation
- Tasks with multiple independent parts (research + implement + review) were handled sequentially by a single agent, which is slower and burns more context
- No rules existed to guide Claude on when to auto-dispatch vs do it alone

## What

- Add `.claude/agents/` directory with 3 custom subagents (auto-routed via `description` field):
  - `researcher` — web search + read-only investigation, Haiku model (cost-efficient)
  - `shell-reviewer` — shellcheck + manual audit of `.sh` scripts, Haiku model
  - `security-auditor` — hook/config/secret security review, Haiku model
- Update `CLAUDE.md` with explicit multi-agent dispatch rules table:
  - Parallel dispatch: 3+ independent tasks → spawn simultaneously
  - Sequential dispatch: output dependencies → chain agents
  - No dispatch: single-file changes under 30s
- Add `link .claude/agents "$HOME/.claude/agents"` to `setup.sh` for symlink management

## Reference

- https://code.claude.com/docs/en/sub-agents
- https://code.claude.com/docs/en/agent-teams
- https://claudefa.st/blog/guide/agents/sub-agent-best-practices