### PR TITLE
feat: guard rm — block dangerous flags, allow plain rm with user confirmation

### DIFF
--- a/.claude/hooks/guard-rm.sh
+++ b/.claude/hooks/guard-rm.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# PreToolUse hook: guard rm commands
+#
+# Policy:
+#   BLOCK  — any rm with recursive (-r/-R/--recursive) or force (-f/-F/--force) flags
+#   PASS   — plain rm without dangerous flags (normal permission flow will ask user)
+#
+# Why a hook instead of deny rules only:
+#   deny rules do prefix matching. "Bash(rm -rf:*)" misses "rm -fr", "rm -Rf",
+#   "rm -rn", "rm --recursive", etc. A hook catches all flag-order variations.
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Strip quoted strings first to avoid false positives from commit messages like:
+#   git commit -m "remove the rm -rf call"
+# After stripping, split on ; & | and check each segment individually.
+# Only a segment whose FIRST token is "rm" is evaluated.
+STRIPPED=$(echo "$COMMAND" | sed "s/'[^']*'//g" | sed 's/"[^"]*"//g')
+
+while IFS= read -r segment; do
+  segment="${segment#"${segment%%[![:space:]]*}"}"  # trim leading whitespace
+  [ -z "$segment" ] && continue
+
+  # Only proceed if this segment starts with "rm" as a command
+  echo "$segment" | grep -qE '^rm[[:space:]]' || continue
+
+  # Block if rm has any dangerous flag:
+  #   -r / -R  recursive  |  -f / -F  force  |  combined e.g. -fr -Rf -rn
+  #   --recursive / --force  long-form equivalents
+  if echo "$segment" | grep -qE '^rm[[:space:]].*-[a-zA-Z]*[rRfF]' || \
+     echo "$segment" | grep -qE '^rm[[:space:]].*(--recursive|--force)'; then
+    echo "BLOCKED: rm with recursive or force flags is not allowed." >&2
+    echo "  Use plain 'rm <file>' instead — Claude will ask for your approval first." >&2
+    exit 2
+  fi
+done < <(echo "$STRIPPED" | tr ';&|' '\n')
+
+# Plain rm (no dangerous flags) — exit 0 so normal permission flow prompts user
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,7 +87,12 @@
       "Read(**/secrets.json)",
       "Read(**/service-account*.json)",
       "Bash(rm -rf:*)",
+      "Bash(rm -fr:*)",
       "Bash(rm -r:*)",
+      "Bash(rm -R:*)",
+      "Bash(rm -f:*)",
+      "Bash(rm --recursive:*)",
+      "Bash(rm --force:*)",
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
       "Bash(git reset --hard:*)",
@@ -104,6 +109,15 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/block-sensitive-access.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/guard-rm.sh"
           }
         ]
       },


### PR DESCRIPTION
## Why

- `rm -rf` and `rm -r` were in `deny` rules but prefix matching missed variants like `rm -fr`, `rm -Rf`, `rm --force`, etc.
- Plain `rm file` was effectively unusable through Claude Code even though it should be fine with user confirmation

## What

- Add `guard-rm.sh` PreToolUse hook with two-step logic:
  1. Strip quoted strings first (prevents false positives from `git commit -m "... rm -rf ..."`)
  2. Split on `;`/`&`/`|`, check only segments whose first token is `rm`
  - **BLOCK**: any `-r`/`-R`/`-f`/`-F`/`--recursive`/`--force` flag in any order/combination
  - **PASS**: plain `rm <file>` without dangerous flags → normal permission flow asks user
- Expand `deny` rules with `rm -fr`, `rm -R`, `rm -f`, `rm --recursive`, `rm --force` as defense-in-depth

## Reference

- N/A