### PR TITLE
feat: add Ping notification when Claude needs user confirmation

### DIFF
--- a/.claude/hooks/notify-ask.sh
+++ b/.claude/hooks/notify-ask.sh
@@ -1,40 +1,55 @@
 #!/bin/bash
 # Hook: notify user when Claude needs confirmation or asks a question
 #
-# Approach (layered):
-#   1. PreToolUse(Bash)         — detect commands NOT in allow list → will show
-#                                 permission dialog → Ping before dialog appears
-#   2. PreToolUse(AskUserQuestion) — Claude explicitly asks a yes/no question
-#   3. Notification(catch-all)  — fallback for any remaining notification events
-#                                 (Notification(permission_prompt) is unreliable per
-#                                  issues #11964 and #17170)
-#
-# Sound: Ping (distinct from Glass=complete, Basso=error)
+# Performance notes:
+#   - Allow-list pattern is cached in /tmp and rebuilt only when settings.json changes
+#   - afplay (sound) and osascript (notification) run async so the hook exits immediately
 
 INPUT=$(cat)
-HOOK_EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // ""')
-TOOL_NAME=$(echo "$INPUT"  | jq -r '.tool_name // ""')
+
+# Extract fields in one jq call
+read -r HOOK_EVENT TOOL_NAME < <(
+  echo "$INPUT" | jq -r '[.hook_event_name // "", .tool_name // ""] | @tsv'
+)
 
 TITLE="Claude Code - 確認が必要"
 SOUND="Ping"
 
-# ── Helper: check if a Bash command is pre-approved (in allow list) ──────────
-is_allowed_bash() {
-  local cmd="$1"
+# ── Fire sound + notification immediately (async) ────────────────────────────
+notify() {
+  local msg="${1:0:120}"
+  # Sound: afplay is fast and fires independently
+  command -v afplay >/dev/null 2>&1 && { afplay "/System/Library/Sounds/${SOUND}.aiff" 2>/dev/null & disown; }
+  # Visual notification (no sound name to avoid double-play)
+  command -v osascript >/dev/null 2>&1 && {
+    osascript -e "display notification \"$msg\" with title \"$TITLE\"" 2>/dev/null &
+    disown
+  }
+}
+
+# ── Allow-list cache: rebuild only when settings.json changes ────────────────
+# Compiles all "Bash(prefix:*)" entries into one grep pattern: "^prefix( |$)|..."
+_allow_pattern() {
   local settings="$HOME/.claude/settings.json"
-  [ -f "$settings" ] || return 1  # unknown → treat as needing approval
+  local cache="/tmp/claude_bash_allow.pat"
+  [ -f "$settings" ] || { printf ""; return; }
+  if [ ! -f "$cache" ] || [ "$settings" -nt "$cache" ]; then
+    jq -r '
+      [.permissions.allow[]?
+       | select(startswith("Bash("))
+       | ltrimstr("Bash(") | rtrimstr(":*")
+       | "^" + . + "( |$)"]
+      | join("|")
+    ' "$settings" 2>/dev/null > "$cache"
+  fi
+  cat "$cache"
+}
 
-  # Read Bash allow patterns: "Bash(prefix:*)" → check if cmd starts with prefix
-  while IFS= read -r entry; do
-    case "$entry" in
-      Bash\(*)
-        prefix=$(echo "$entry" | sed 's/^Bash(\(.*\):\*.*)/\1/')
-        echo "$cmd" | grep -qE "^${prefix}(\s|$)" && return 0
-        ;;
-    esac
-  done < <(jq -r '.permissions.allow[] // empty' "$settings" 2>/dev/null)
-
-  return 1  # not found in allow list → will need approval
+is_allowed_bash() {
+  local pattern
+  pattern=$(_allow_pattern)
+  [ -z "$pattern" ] && return 1
+  echo "$1" | grep -qE "$pattern"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -44,39 +59,29 @@ case "$HOOK_EVENT" in
     case "$TOOL_NAME" in
       Bash)
         CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
-        is_allowed_bash "$CMD" && exit 0   # auto-approved, no dialog → skip
-        MSG="承認が必要: ${CMD:0:80}"
+        is_allowed_bash "$CMD" && exit 0
+        notify "承認が必要: ${CMD:0:80}"
         ;;
       AskUserQuestion)
         MSG=$(echo "$INPUT" | jq -r '
-          .tool_input.question //
-          (.tool_input.questions[0] // "質問があります")
+          .tool_input.question // (.tool_input.questions[0] // "質問があります")
         ')
+        notify "$MSG"
         ;;
-      *)
-        exit 0
-        ;;
+      *) exit 0 ;;
     esac
     ;;
 
   Notification)
-    # Catch-all fallback. Skip noisy types if notification_type is present.
     NOTIF_TYPE=$(echo "$INPUT" | jq -r '.notification_type // ""')
     case "$NOTIF_TYPE" in
       idle_prompt|auth_success) exit 0 ;;
     esac
     MSG=$(echo "$INPUT" | jq -r '.message // "確認が必要です"')
+    notify "$MSG"
     ;;
 
-  *)
-    exit 0
-    ;;
+  *) exit 0 ;;
 esac
-
-MSG="${MSG:0:120}"
-
-if command -v osascript >/dev/null 2>&1; then
-  osascript -e "display notification \"$MSG\" with title \"$TITLE\" sound name \"$SOUND\"" 2>/dev/null || true
-fi
 
 exit 0

--- a/.claude/hooks/notify-ask.sh
+++ b/.claude/hooks/notify-ask.sh
@@ -12,16 +12,10 @@ INPUT=$(cat)
 SOUND="Submarine"
 TITLE="Claude Code - 確認が必要"
 
-# ── Sound: fire immediately in background (before any other processing) ───────
-_play() {
-  /usr/bin/afplay "/System/Library/Sounds/${SOUND}.aiff" 2>/dev/null &
-  disown $! 2>/dev/null
-}
-
-# ── Visual notification (async) ───────────────────────────────────────────────
+# ── Sound + notification in one osascript call (atomic, no sync issue) ────────
 _notify() {
   local msg="${1:0:120}"
-  /usr/bin/osascript -e "display notification \"$msg\" with title \"$TITLE\"" 2>/dev/null &
+  /usr/bin/osascript -e "display notification \"$msg\" with title \"$TITLE\" sound name \"$SOUND\"" 2>/dev/null &
   disown $! 2>/dev/null
 }
 

--- a/.claude/hooks/notify-ask.sh
+++ b/.claude/hooks/notify-ask.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # Hook: notify user when Claude needs confirmation or asks a question
 #
-# Triggered by two events:
-#   1. Notification (matcher: permission_prompt) — tool permission dialogs (yes/no)
-#   2. PreToolUse  (matcher: AskUserQuestion)   — Claude explicitly asks a question
+# Approach (layered):
+#   1. PreToolUse(Bash)         — detect commands NOT in allow list → will show
+#                                 permission dialog → Ping before dialog appears
+#   2. PreToolUse(AskUserQuestion) — Claude explicitly asks a yes/no question
+#   3. Notification(catch-all)  — fallback for any remaining notification events
+#                                 (Notification(permission_prompt) is unreliable per
+#                                  issues #11964 and #17170)
 #
-# Sound: Ping (distinctive; different from Glass=complete, Basso=error)
+# Sound: Ping (distinct from Glass=complete, Basso=error)
 
 INPUT=$(cat)
 HOOK_EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // ""')
@@ -14,24 +18,61 @@ TOOL_NAME=$(echo "$INPUT"  | jq -r '.tool_name // ""')
 TITLE="Claude Code - 確認が必要"
 SOUND="Ping"
 
+# ── Helper: check if a Bash command is pre-approved (in allow list) ──────────
+is_allowed_bash() {
+  local cmd="$1"
+  local settings="$HOME/.claude/settings.json"
+  [ -f "$settings" ] || return 1  # unknown → treat as needing approval
+
+  # Read Bash allow patterns: "Bash(prefix:*)" → check if cmd starts with prefix
+  while IFS= read -r entry; do
+    case "$entry" in
+      Bash\(*)
+        prefix=$(echo "$entry" | sed 's/^Bash(\(.*\):\*.*)/\1/')
+        echo "$cmd" | grep -qE "^${prefix}(\s|$)" && return 0
+        ;;
+    esac
+  done < <(jq -r '.permissions.allow[] // empty' "$settings" 2>/dev/null)
+
+  return 1  # not found in allow list → will need approval
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+
 case "$HOOK_EVENT" in
+  PreToolUse)
+    case "$TOOL_NAME" in
+      Bash)
+        CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+        is_allowed_bash "$CMD" && exit 0   # auto-approved, no dialog → skip
+        MSG="承認が必要: ${CMD:0:80}"
+        ;;
+      AskUserQuestion)
+        MSG=$(echo "$INPUT" | jq -r '
+          .tool_input.question //
+          (.tool_input.questions[0] // "質問があります")
+        ')
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    ;;
+
   Notification)
+    # Catch-all fallback. Skip noisy types if notification_type is present.
+    NOTIF_TYPE=$(echo "$INPUT" | jq -r '.notification_type // ""')
+    case "$NOTIF_TYPE" in
+      idle_prompt|auth_success) exit 0 ;;
+    esac
     MSG=$(echo "$INPUT" | jq -r '.message // "確認が必要です"')
     ;;
-  PreToolUse)
-    [ "$TOOL_NAME" = "AskUserQuestion" ] || exit 0
-    # tool_input may have .question (string) or .questions (array)
-    MSG=$(echo "$INPUT" | jq -r '
-      .tool_input.question //
-      (.tool_input.questions[0] // "質問があります")
-    ')
-    ;;
+
   *)
     exit 0
     ;;
 esac
 
-# Truncate to keep notification readable
 MSG="${MSG:0:120}"
 
 if command -v osascript >/dev/null 2>&1; then

--- a/.claude/hooks/notify-ask.sh
+++ b/.claude/hooks/notify-ask.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Hook: notify user when Claude needs confirmation or asks a question
+#
+# Triggered by two events:
+#   1. Notification (matcher: permission_prompt) — tool permission dialogs (yes/no)
+#   2. PreToolUse  (matcher: AskUserQuestion)   — Claude explicitly asks a question
+#
+# Sound: Ping (distinctive; different from Glass=complete, Basso=error)
+
+INPUT=$(cat)
+HOOK_EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // ""')
+TOOL_NAME=$(echo "$INPUT"  | jq -r '.tool_name // ""')
+
+TITLE="Claude Code - 確認が必要"
+SOUND="Ping"
+
+case "$HOOK_EVENT" in
+  Notification)
+    MSG=$(echo "$INPUT" | jq -r '.message // "確認が必要です"')
+    ;;
+  PreToolUse)
+    [ "$TOOL_NAME" = "AskUserQuestion" ] || exit 0
+    # tool_input may have .question (string) or .questions (array)
+    MSG=$(echo "$INPUT" | jq -r '
+      .tool_input.question //
+      (.tool_input.questions[0] // "質問があります")
+    ')
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# Truncate to keep notification readable
+MSG="${MSG:0:120}"
+
+if command -v osascript >/dev/null 2>&1; then
+  osascript -e "display notification \"$MSG\" with title \"$TITLE\" sound name \"$SOUND\"" 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/hooks/notify-ask.sh
+++ b/.claude/hooks/notify-ask.sh
@@ -1,37 +1,35 @@
 #!/bin/bash
 # Hook: notify user when Claude needs confirmation or asks a question
 #
-# Performance notes:
-#   - Allow-list pattern is cached in /tmp and rebuilt only when settings.json changes
-#   - afplay (sound) and osascript (notification) run async so the hook exits immediately
+# Triggered by PreToolUse only (Notification hook removed — it caused double-firing
+# alongside PreToolUse, resulting in two sounds per confirmation).
+#
+# Latency optimisation: afplay fires in background as the very first action,
+# before any allow-list check or osascript, so sound plays at earliest opportunity.
 
 INPUT=$(cat)
 
-# Extract fields in one jq call
-read -r HOOK_EVENT TOOL_NAME < <(
-  echo "$INPUT" | jq -r '[.hook_event_name // "", .tool_name // ""] | @tsv'
-)
-
+SOUND="Submarine"
 TITLE="Claude Code - 確認が必要"
-SOUND="Ping"
 
-# ── Fire sound + notification immediately (async) ────────────────────────────
-notify() {
-  local msg="${1:0:120}"
-  # Sound: afplay is fast and fires independently
-  command -v afplay >/dev/null 2>&1 && { afplay "/System/Library/Sounds/${SOUND}.aiff" 2>/dev/null & disown; }
-  # Visual notification (no sound name to avoid double-play)
-  command -v osascript >/dev/null 2>&1 && {
-    osascript -e "display notification \"$msg\" with title \"$TITLE\"" 2>/dev/null &
-    disown
-  }
+# ── Sound: fire immediately in background (before any other processing) ───────
+_play() {
+  /usr/bin/afplay "/System/Library/Sounds/${SOUND}.aiff" 2>/dev/null &
+  disown $! 2>/dev/null
 }
 
-# ── Allow-list cache: rebuild only when settings.json changes ────────────────
-# Compiles all "Bash(prefix:*)" entries into one grep pattern: "^prefix( |$)|..."
+# ── Visual notification (async) ───────────────────────────────────────────────
+_notify() {
+  local msg="${1:0:120}"
+  /usr/bin/osascript -e "display notification \"$msg\" with title \"$TITLE\"" 2>/dev/null &
+  disown $! 2>/dev/null
+}
+
+# ── Allow-list cache ──────────────────────────────────────────────────────────
+# Compiles "Bash(prefix:*)" entries into one grep ERE pattern, cached in /tmp.
+# Rebuilt only when settings.json is newer than cache file.
 _allow_pattern() {
-  local settings="$HOME/.claude/settings.json"
-  local cache="/tmp/claude_bash_allow.pat"
+  local settings="$HOME/.claude/settings.json" cache="/tmp/claude_bash_allow.pat"
   [ -f "$settings" ] || { printf ""; return; }
   if [ ! -f "$cache" ] || [ "$settings" -nt "$cache" ]; then
     jq -r '
@@ -45,43 +43,37 @@ _allow_pattern() {
   cat "$cache"
 }
 
-is_allowed_bash() {
-  local pattern
-  pattern=$(_allow_pattern)
+_is_allowed() {
+  local pattern; pattern=$(_allow_pattern)
   [ -z "$pattern" ] && return 1
-  echo "$1" | grep -qE "$pattern"
+  printf '%s' "$1" | grep -qE "$pattern"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
 
-case "$HOOK_EVENT" in
-  PreToolUse)
-    case "$TOOL_NAME" in
-      Bash)
-        CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
-        is_allowed_bash "$CMD" && exit 0
-        notify "承認が必要: ${CMD:0:80}"
-        ;;
-      AskUserQuestion)
-        MSG=$(echo "$INPUT" | jq -r '
-          .tool_input.question // (.tool_input.questions[0] // "質問があります")
-        ')
-        notify "$MSG"
-        ;;
-      *) exit 0 ;;
-    esac
-    ;;
+read -r HOOK_EVENT TOOL_NAME < <(
+  printf '%s' "$INPUT" | jq -r '[.hook_event_name // "", .tool_name // ""] | @tsv'
+)
 
-  Notification)
-    NOTIF_TYPE=$(echo "$INPUT" | jq -r '.notification_type // ""')
-    case "$NOTIF_TYPE" in
-      idle_prompt|auth_success) exit 0 ;;
-    esac
-    MSG=$(echo "$INPUT" | jq -r '.message // "確認が必要です"')
-    notify "$MSG"
-    ;;
+[ "$HOOK_EVENT" = "PreToolUse" ] || exit 0
 
-  *) exit 0 ;;
+case "$TOOL_NAME" in
+  Bash)
+    CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
+    _is_allowed "$CMD" && exit 0
+    _play
+    _notify "承認が必要: ${CMD:0:80}"
+    ;;
+  AskUserQuestion)
+    MSG=$(printf '%s' "$INPUT" | jq -r '
+      .tool_input.question // (.tool_input.questions[0] // "質問があります")
+    ')
+    _play
+    _notify "$MSG"
+    ;;
+  *)
+    exit 0
+    ;;
 esac
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,6 +104,15 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notify-ask.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Read|Edit|Write|Bash|Grep",
         "hooks": [
           {
@@ -166,6 +175,17 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/notify-done.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notify-ask.sh"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -179,16 +179,7 @@
         ]
       }
     ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/notify-ask.sh"
-          }
-        ]
-      }
-    ]
+    "Notification": []
   },
   "statusLine": {
     "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,7 +104,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "AskUserQuestion",
+        "matcher": "AskUserQuestion|Bash",
         "hooks": [
           {
             "type": "command",
@@ -181,7 +181,6 @@
     ],
     "Notification": [
       {
-        "matcher": "permission_prompt",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Why

- Task completion (Glass) and error (Basso) notifications existed, but there was no alert when Claude needed user input or permission confirmation

## What

- Add `notify-ask.sh` hook with `Ping` sound, triggered by two events:
  - `Notification` with `permission_prompt` matcher — fires on tool permission dialogs (the yes/no approval prompts)
  - `PreToolUse` with `AskUserQuestion` matcher — fires when Claude explicitly asks a question
- Notification message is extracted from the payload (`.message` for Notification events, `.tool_input.question` / `.tool_input.questions[0]` for AskUserQuestion), truncated to 120 chars

## Sound mapping

| Event | Sound |
|---|---|
| Task complete | Glass |
| Error | Basso |
| **Needs confirmation / question** | **Ping** |

## Reference

- https://code.claude.com/docs/en/hooks
- https://github.com/anthropics/claude-code/issues/11964 (notification_type bug — matcher side works correctly)
- https://github.com/anthropics/claude-code/issues/12048