### PR TITLE
fix: resolve hook errors in Claude Code settings

### DIFF
--- a/.claude/hooks/notify-ask.sh
+++ b/.claude/hooks/notify-ask.sh
@@ -55,14 +55,12 @@ case "$TOOL_NAME" in
   Bash)
     CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
     _is_allowed "$CMD" && exit 0
-    _play
     _notify "承認が必要: ${CMD:0:80}"
     ;;
   AskUserQuestion)
     MSG=$(printf '%s' "$INPUT" | jq -r '
       .tool_input.question // (.tool_input.questions[0] // "質問があります")
     ')
-    _play
     _notify "$MSG"
     ;;
   *)

--- a/.claude/hooks/notify-ask.sh
+++ b/.claude/hooks/notify-ask.sh
@@ -30,7 +30,7 @@ _allow_pattern() {
     jq -r '
       [.permissions.allow[]?
        | select(startswith("Bash("))
-       | ltrimstr("Bash(") | rtrimstr(":*")
+       | ltrimstr("Bash(") | rtrimstr(":*)")
        | "^" + . + "( |$)"]
       | join("|")
     ' "$settings" 2>/dev/null > "$cache"

--- a/.claude/hooks/notify-ask.sh
+++ b/.claude/hooks/notify-ask.sh
@@ -9,14 +9,15 @@
 
 INPUT=$(cat)
 
-SOUND="Frog"
+SOUND_FILE="/System/Library/Sounds/Frog.aiff"
 TITLE="Claude Code - 確認が必要"
 
-# ── Sound + notification in one osascript call (atomic, no sync issue) ────────
+# ── Sound (afplay) + notification (osascript) ────────────────────────────────
 _notify() {
   local msg="${1:0:120}"
-  /usr/bin/osascript -e "display notification \"$msg\" with title \"$TITLE\" sound name \"$SOUND\"" 2>/dev/null &
-  disown $! 2>/dev/null
+  afplay "$SOUND_FILE" &
+  /usr/bin/osascript -e "display notification \"$msg\" with title \"$TITLE\"" 2>/dev/null &
+  disown 2>/dev/null
 }
 
 # ── Allow-list cache ──────────────────────────────────────────────────────────

--- a/.claude/hooks/notify-done.sh
+++ b/.claude/hooks/notify-done.sh
@@ -7,16 +7,15 @@ IS_ERROR=$(echo "$INPUT" | jq -r '.is_error // false')
 if [ "$IS_ERROR" = "true" ]; then
   TITLE="Claude Code - エラー"
   MSG="タスクがエラーで終了しました"
-  SOUND="Basso"
+  SOUND_FILE="/System/Library/Sounds/Basso.aiff"
 else
   TITLE="Claude Code - 完了"
   MSG="タスクが完了しました"
-  SOUND="Glass"
+  SOUND_FILE="/System/Library/Sounds/Glass.aiff"
 fi
 
-# macOS notification with sound (sound name plays via Notification Center)
-if command -v osascript >/dev/null 2>&1; then
-  osascript -e "display notification \"$MSG\" with title \"$TITLE\" sound name \"$SOUND\"" 2>/dev/null || true
-fi
+# afplay for reliable sound, osascript for visual notification
+afplay "$SOUND_FILE" &
+osascript -e "display notification \"$MSG\" with title \"$TITLE\"" 2>/dev/null || true
 
 exit 0


### PR DESCRIPTION
## Why

- Claude Code hooks were failing with "Failed with non-blocking status code: /bin/sh:" errors
- The `notify-ask.sh` hook called an undefined `_play` function, causing command-not-found noise on every invocation

## What

- Remove undefined `_play` function calls from `notify-ask.sh` (`_notify` already handles sound via osascript)
- Allow `gh pr diff` command without confirmation in settings
- Fix PR template formatting

## Reference

- N/A