### PR TITLE
fix: bump uuid to 13.0.1 (CVE-2026-41907)

### DIFF
--- a/.config/opencode/package-lock.json
+++ b/.config/opencode/package-lock.json
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"


### PR DESCRIPTION
## Why

- Dependabot alert https://github.com/jedipunkz/dotfiles/security/dependabot/2 (CVE-2026-41907, GHSA-w5hq-g745-h8pq, CVSS 7.5)
- `uuid` v3/v5/v6 silently write past the bounds of caller-provided buffers; patched in 13.0.1
- Affects the transitive `uuid` dep of `@opencode-ai/plugin` resolved in `.config/opencode/package-lock.json`

## What

- Update `node_modules/uuid` entry in `.config/opencode/package-lock.json` from 13.0.0 to 13.0.1 (resolved URL and integrity hash updated)
- No other lockfile entries touched; `package.json` is gitignored under `.config/opencode/`, so the change is scoped to the locked uuid version

## Reference

- Advisory: https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq
- Release: https://github.com/uuidjs/uuid/releases/tag/v13.0.1