### PR TITLE
feat: bind ctrl+enter to submit and enter to newline

### DIFF
--- a/.claude/keybindings.json
+++ b/.claude/keybindings.json
@@ -5,9 +5,16 @@
     {
       "context": "Chat",
       "bindings": {
-        "enter": "chat:submit",
+        "enter": "chat:newline",
         "ctrl+enter": "chat:submit",
         "shift+enter": "chat:newline"
+      }
+    },
+    {
+      "context": "Autocomplete",
+      "bindings": {
+        "enter": "autocomplete:accept",
+        "ctrl+enter": "autocomplete:accept"
       }
     }
   ]


### PR DESCRIPTION
## Why

- Configure Claude Code CLI so that Enter inserts a newline and Ctrl+Enter submits, which is now possible after the upstream fix shipped in Claude Code v2.1.141 (anthropics/claude-code#57139, #60156)
- N/A

## What

- Rebind `enter` to `chat:newline` and keep `ctrl+enter` as `chat:submit` in the `Chat` context of `.claude/keybindings.json`
- Add an explicit `Autocomplete` context that maps `enter` and `ctrl+enter` to `autocomplete:accept`, so the slash command picker still confirms selections after the Chat-level `enter` was rebound

## Reference

- https://github.com/anthropics/claude-code/issues/57139
- https://github.com/anthropics/claude-code/issues/60156
- https://github.com/anthropics/claude-code/issues/62623 (known residual issue: submitting a slash command directly via ctrl+enter may still fail on some versions; the Autocomplete binding above mitigates the common picker-confirm case)