### PR TITLE
feat: add herdr terminal multiplexer config

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,18 @@
+onboarding = false
+
+[ui.toast]
+delivery = "terminal"
+
+[ui]
+show_agent_labels_on_pane_borders = true
+
+[theme]
+name = "catppuccin"
+
+[keys]
+prefix = "ctrl+t"
+split_vertical = "prefix+|"
+split_horizontal = "prefix+\""
+previous_workspace = "prefix+["
+next_workspace = "prefix+]"
+detach = "prefix+d"

--- a/setup.sh
+++ b/setup.sh
@@ -104,6 +104,11 @@ link .config/opencode "$HOME/.config/opencode"
 link .config/eza "$HOME/.config/eza"
 link .config/karabiner "$HOME/.config/karabiner"
 
+# herdr stores runtime state (sockets, logs, session.json) under ~/.config/herdr,
+# so link only the config.toml file rather than the directory.
+makedir "$HOME/.config/herdr" 700
+link .config/herdr/config.toml "$HOME/.config/herdr/config.toml"
+
 # .claude directory links
 link .claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"
 link .claude/settings.json "$HOME/.claude/settings.json"


### PR DESCRIPTION
## Why

- Install herdr (terminal workspace manager for AI coding agents) and start managing its configuration through dotfiles.
- Related issue or ticket: N/A

## What

- Add `.config/herdr/config.toml` with custom keybindings:
  - `prefix` rebound from `ctrl+b` to `ctrl+t`
  - `split_vertical` = `prefix+|`, `split_horizontal` = `prefix+"`
  - `previous_workspace` = `prefix+[`, `next_workspace` = `prefix+]`
  - `detach` rebound from `prefix+q` to `prefix+d`
  - Catppuccin theme, terminal toast delivery, agent labels on pane borders
- Update `setup.sh` to symlink only `~/.config/herdr/config.toml` (not the directory) so herdr's runtime state (sockets, logs, session.json) stays out of the dotfiles repo.

## Reference

- herdr docs: https://herdr.dev/docs/configuration/