### PR TITLE
feat: expand herdr config and add codex repo

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -62,6 +62,9 @@ trust_level = "trusted"
 [projects."/Users/thirai/tmp/amazon-coupon-extension"]
 trust_level = "trusted"
 
+[projects."/Users/thirai/ghq/github.com/jedipunkz/fuzz.fish"]
+trust_level = "trusted"
+
 [tui.model_availability_nux]
 "gpt-5.5" = 4
 

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -7,7 +7,7 @@ delivery = "terminal"
 show_agent_labels_on_pane_borders = true
 
 [theme]
-name = "catppuccin"
+name = "tokyo-night"
 
 [keys]
 prefix = "ctrl+t"

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,13 +1,24 @@
 onboarding = false
 
+[terminal]
+new_cwd = "follow"
+
 [ui.toast]
 delivery = "terminal"
 
 [ui]
 show_agent_labels_on_pane_borders = true
+sidebar_width = 28
+accent = "#7aa2f7"
 
 [theme]
 name = "tokyo-night"
+
+[worktrees]
+directory = "~/.ax/worktrees"
+
+[advanced]
+scrollback_limit_bytes = 524288000
 
 [keys]
 prefix = "ctrl+t"


### PR DESCRIPTION
## Why

- Tune herdr to better fit my daily workflow (worktree-based agent swarms, long-running agent sessions, tokyo-night UI).
- Register the codex repo entry alongside other dotfiles.
- Related issue: N/A

## What

- Add ~/.ax/worktrees as the herdr worktree directory.
- Bump scrollback_limit_bytes to 500MB for long agent sessions.
- Set new_cwd = "follow" so new panes inherit the parent pane cwd.
- Shrink sidebar_width to 28 and set accent to tokyo-night blue (#7aa2f7).
- Switch herdr theme.
- Add a codex config entry.

## Reference

- [herdr configuration docs](https://herdr.dev/docs/configuration/)