### PR TITLE
chore: add auto PR workflow for feature branches

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,58 @@
+name: Auto PR
+
+on:
+  push:
+    branches:
+      - deathstar
+      - chewbacca
+      - darth
+      - kw
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create PR if diff exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if git diff --quiet "origin/main...origin/${BRANCH}"; then
+            echo "No diff between ${BRANCH} and main. Skipping."
+            exit 0
+          fi
+
+          open_prs=$(gh pr list --head "${BRANCH}" --base main --state open --json number --jq 'length')
+          if [ "${open_prs}" != "0" ]; then
+            echo "An open PR from ${BRANCH} to main already exists. Skipping."
+            exit 0
+          fi
+
+          {
+            echo "## Why"
+            echo ""
+            echo "- Automated PR: \`${BRANCH}\` has changes not yet merged into \`main\`"
+            echo ""
+            echo "## What"
+            echo ""
+            git log --format='- %s' "origin/main..origin/${BRANCH}"
+            echo ""
+            echo "## Reference"
+            echo ""
+            echo "- N/A"
+          } > /tmp/pr_body.md
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "Merge ${BRANCH} into main" \
+            --body-file /tmp/pr_body.md


### PR DESCRIPTION
## Why

- Long-lived working branches (`deathstar`, `chewbacca`, `darth`, `kw`) accumulate changes that should be proposed to `main` without manual PR creation
- N/A (no related issue)

## What

- Add `.github/workflows/auto-pr.yml` triggered on push to `deathstar`, `chewbacca`, `darth`, and `kw`
- Skip when the branch has no diff against `main`
- Skip when an open PR from the branch to `main` already exists
- Create the PR via `gh pr create` with the unmerged commit list embedded in the body

## Reference

- N/A